### PR TITLE
Adds Running Status message compatibility

### DIFF
--- a/midiv1/message.go
+++ b/midiv1/message.go
@@ -5,16 +5,46 @@ import (
 	"fmt"
 )
 
-// MessageBuilder represents MIDI message data that can be both marshalled and unmarshalled.
-type MessageBuilder interface {
-	// MarshalMIDI marshalls a MIDI message into its raw bytes
+// MessageMarshaler represents MIDI message data that can be marshalled.
+type MessageMarshaler interface {
+	// MarshalMIDI marshalls a MIDI message into its raw bytes.
 	MarshalMIDI() ([]byte, error)
+}
 
-	// UnmarshalMIDI unmarshalls raw bytes into a MIDI message
+// MessageUnmarshaler represents MIDI message data that can be unmarshalled.
+type MessageUnmarshaler interface {
+	// UnmarshalMIDI unmarshalls raw bytes into a MIDI message.
 	UnmarshalMIDI(b []byte) error
 }
 
+// MessageBuilder represents MIDI message data that can be both marshalled and unmarshalled.
+type MessageBuilder interface {
+	MessageMarshaler
+	MessageUnmarshaler
+}
+
+// RunningStatusMessageMarshaler represents running status MIDI message data that can be marshalled.
+type RunningStatusMessageMarshaler interface {
+	// MarshalRunningStatusMIDI marshalls a running status MIDI message into its raw bytes.
+	MarshalRunningStatusMIDI() ([]byte, error)
+}
+
+// RunningStatusMessageUnmarshaler represents running status MIDI message data that can be unmarshalled.
+type RunningStatusMessageUnmarshaler interface {
+	// UnmarshalRunningStatusMIDI unmarshalls raw bytes into a running status MIDI message.
+	UnmarshalRunningStatusMIDI(b []byte) error
+}
+
+// RunningStatusMessageBuilder represents running status MIDI message data that can be both marshalled and unmarshalled.
+type RunningStatusMessageBuilder interface {
+	RunningStatusMessageMarshaler
+	RunningStatusMessageUnmarshaler
+}
+
 var (
+	// ErrMarshallingMessage represents an error marshalling a MIDI message.
+	ErrMarshallingMessage error = errors.New("error marshalling MIDI message")
+
 	// ErrUnmarshallingMessage represents an error unmarshalling a MIDI message.
 	ErrUnmarshallingMessage error = errors.New("error unmarshalling MIDI message")
 )
@@ -48,6 +78,11 @@ func ByteHasStatusMSB(b byte) bool {
 //
 // Example: 0b11010000 (Status message for Channel Pressure)
 type Status Nibble
+
+// MakeStatus creates and returns a MIDI message status byte by OR-ing the status and channel nibbles.
+func MakeStatusByte(statusNibble Status, channelNibble Channel) byte {
+	return byte(statusNibble) | byte(channelNibble)
+}
 
 // Channel represents second four bits of the MIDI message status byte (the ID of the channel).
 //

--- a/midiv1/message_test.go
+++ b/midiv1/message_test.go
@@ -57,6 +57,30 @@ func Test_ByteHasStatusMSB(t *testing.T) {
 	}
 }
 
+func Test_MakeStatusByte(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		statusNibble  Status
+		channelNibble Channel
+		expected      byte
+	}{
+		"status byte is expected value": {
+			statusNibble:  Status(0b10010000),
+			channelNibble: Channel(5),
+			expected:      0b10010101,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := MakeStatusByte(test.statusNibble, test.channelNibble)
+			if got != test.expected {
+				t.Fatalf("expected %v, got %v", test.expected, got)
+			}
+		})
+	}
+}
+
 func Test_NewChannel(t *testing.T) {
 	t.Parallel()
 	tests := map[string]struct {

--- a/midiv1/note_on_message.go
+++ b/midiv1/note_on_message.go
@@ -6,6 +6,9 @@ const (
 	// NoteOnMessageStatusCode represents the message code within the status nibble
 	NoteOnMessageCode Nibble = 0b00010000
 
+	// NoteOnMessageLength represents the number of bytes in a full Note-On message.
+	NoteOnMessageLength int = 3
+
 	// NoteOnMessageStatusNibble represents the status nibble within the status byte
 	NoteOnMessageStatusNibble Status = Status(StatusMessageMSB) | Status(NoteOnMessageCode)
 )
@@ -25,7 +28,15 @@ type NoteOnMessage struct {
 // MarshalMIDI marshalls a NoteOnMessage MIDI message into its raw bytes
 func (nom NoteOnMessage) MarshalMIDI() ([]byte, error) {
 	return []byte{
-		byte(NoteOnMessageStatusNibble) | byte(nom.Channel),
+		MakeStatusByte(NoteOnMessageStatusNibble, nom.Channel),
+		byte(nom.Note),
+		byte(nom.Velocity),
+	}, nil
+}
+
+// MarshalRunningStatusMIDI marshalls a running status MIDI message into its raw bytes.
+func (nom NoteOnMessage) MarshalRunningStatusMIDI() ([]byte, error) {
+	return []byte{
 		byte(nom.Note),
 		byte(nom.Velocity),
 	}, nil
@@ -38,9 +49,9 @@ func (nom NoteOnMessage) MarshalMIDI() ([]byte, error) {
 //
 // The example forms a Note-On message for channel 2 (index 1), note number 64, velocity value 32.
 func (nom *NoteOnMessage) UnmarshalMIDI(b []byte) error {
-	// a Note-On message sequence uses three bytes
-	if len(b) != 3 {
-		return fmt.Errorf("note-on messages are made up of three bytes, received %d byte(s): %w", len(b), ErrUnmarshallingMessage)
+	// check the number of bytes in the message
+	if len(b) != NoteOnMessageLength {
+		return fmt.Errorf("note-on messages are made up of %d bytes, received %d byte(s): %w", NoteOnMessageLength, len(b), ErrUnmarshallingMessage)
 	}
 
 	// make sure this is a status byte with the proper MSB
@@ -65,6 +76,34 @@ func (nom *NoteOnMessage) UnmarshalMIDI(b []byte) error {
 
 	*nom = NoteOnMessage{
 		Channel:  channel,
+		Note:     note,
+		Velocity: vel,
+	}
+	return nil
+}
+
+// UnmarshalRunningStatusMIDI unmarshalls raw bytes into a NoteOnMessage struct pointer. Note-On running status messages are
+// represented by two bytes (left to right): note number, note velocity.
+//
+// Example: []byte{0b01000000, 0b00100000}
+//
+// The example forms a Note-On running status message for note number 64, velocity value 32.
+func (nom *NoteOnMessage) UnmarshalRunningStatusMIDI(b []byte) error {
+	// check the number of bytes in the running status message
+	if len(b) != NoteOnMessageLength-1 {
+		return fmt.Errorf("note-on running status messages are made up of %d bytes, received %d byte(s): %w", NoteOnMessageLength-1, len(b), ErrUnmarshallingMessage)
+	}
+
+	// form the note number
+	note, err := NewNoteFromByte(b[0])
+	if err != nil {
+		return fmt.Errorf("invalid note number %#v (%v) from running status note byte: %w", b[0], err, ErrUnmarshallingMessage)
+	}
+
+	// form the velocity
+	vel := NewVelocityFromByte(b[1])
+
+	*nom = NoteOnMessage{
 		Note:     note,
 		Velocity: vel,
 	}

--- a/midiv1/note_on_message_test.go
+++ b/midiv1/note_on_message_test.go
@@ -36,6 +36,34 @@ func Test_NoteOnMessage_MarshalMIDI(t *testing.T) {
 	}
 }
 
+func Test_NoteOnMessage_MarshalRunningStatusMIDI(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		message  NoteOnMessage
+		expected []byte
+	}{
+		"running status message marshalls into expected bytes": {
+			message: NoteOnMessage{
+				Note:     64,
+				Velocity: 32,
+			},
+			expected: []byte{0b01000000, 0b00100000},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := test.message.MarshalRunningStatusMIDI()
+			if err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+			if !bytes.Equal(test.expected, got) {
+				t.Fatalf("expected %#v, got %#v", test.expected, got)
+			}
+		})
+	}
+}
+
 func Test_NoteOnMessage_UnmarshalMIDI(t *testing.T) {
 	t.Parallel()
 	tests := map[string]struct {
@@ -69,6 +97,52 @@ func Test_NoteOnMessage_UnmarshalMIDI(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var got NoteOnMessage
 			err := (&got).UnmarshalMIDI(test.b)
+			if test.err == nil && err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+			if test.err != nil {
+				if err == nil {
+					t.Fatalf("expected non-nil %v error, got nil error", test.err)
+				}
+				if !errors.Is(err, test.err) {
+					t.Fatalf("expected %v error, got %v", test.err, err)
+				}
+			}
+			if !reflect.DeepEqual(test.expectedMessage, got) {
+				t.Fatalf("expected %+v, got %+v", test.expectedMessage, got)
+			}
+		})
+	}
+}
+
+func Test_NoteOnMessage_UnmarshalRunningStatusMIDI(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		b               []byte
+		expectedMessage NoteOnMessage
+		err             error
+	}{
+		"byte slice is not proper length": {
+			b:   []byte{0b10010001, 0b10010001, 0b01000000},
+			err: ErrUnmarshallingMessage,
+		},
+		"second byte is an invalid note number": {
+			b:   []byte{0b11000000, 0b00100000},
+			err: ErrUnmarshallingMessage,
+		},
+		"bytes unmarshal into expected message": {
+			b: []byte{0b01000000, 0b00100000},
+			expectedMessage: NoteOnMessage{
+				Note:     64,
+				Velocity: 32,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var got NoteOnMessage
+			err := (&got).UnmarshalRunningStatusMIDI(test.b)
 			if test.err == nil && err != nil {
 				t.Fatalf("expected nil error, got %v", err)
 			}


### PR DESCRIPTION
Adds the ability to use Running Status messages so the data can be marshalled and unmarshalled without producing an explicit status byte.

Closes #20