### PR TITLE
Adds Pitch Bend channel voice messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ go get github.com/matthewfritz/go-midi
    * ✅ [Polyphonic Key Pressure](https://github.com/matthewfritz/go-midi/issues/5)
    * ✅ [Channel Pressure](https://github.com/matthewfritz/go-midi/issues/6)
    * Program Change
-   * Pitch Bend Change
+   * ✅ [Pitch Bend Change](https://github.com/matthewfritz/go-midi/issues/8)
    * Control Change
 
 #### Channel Voice Message Modifiers
 
    * ✅ [Velocity](https://github.com/matthewfritz/go-midi/issues/2)
    * ✅ [Running Status](https://github.com/matthewfritz/go-midi/issues/20)
-   * Pitch
+   * ✅ [Pitch](https://github.com/matthewfritz/go-midi/issues/8)
    * Modulation
 
 #### System Common Messages

--- a/midiv1/channel_pressure_message.go
+++ b/midiv1/channel_pressure_message.go
@@ -47,7 +47,7 @@ func (cpm ChannelPressureMessage) MarshalRunningStatusMIDI() ([]byte, error) {
 //
 // Example: []byte{0b11010001, 0b01000000, 0b00100000}
 //
-// The example forms a Polyphonic Key Pressure message for channel 2 (index 1), note number 64, pressure value 32.
+// The example forms a Channel Pressure message for channel 2 (index 1), note number 64, pressure value 32.
 func (cpm *ChannelPressureMessage) UnmarshalMIDI(b []byte) error {
 	// check the number of bytes in the message
 	if len(b) != ChannelPressureMessageLength {
@@ -87,7 +87,7 @@ func (cpm *ChannelPressureMessage) UnmarshalMIDI(b []byte) error {
 //
 // Example: []byte{0b01000000, 0b00100000}
 //
-// The example forms a Note-On running status message for note number 64, pressure value 32.
+// The example forms a Channel Pressure running status message for note number 64, pressure value 32.
 func (cpm *ChannelPressureMessage) UnmarshalRunningStatusMIDI(b []byte) error {
 	// check the number of bytes in the running status message
 	if len(b) != ChannelPressureMessageLength-1 {

--- a/midiv1/pitch.go
+++ b/midiv1/pitch.go
@@ -37,12 +37,12 @@ func NewPitchBend(pitchBend int) (PitchBend, error) {
 
 // GetLSB returns the least-significant byte of the pitch bend value.
 func (pb PitchBend) GetLSB() byte {
-	return byte(pb & 0x00FF)
+	// https://stackoverflow.com/a/17260211
+	return byte(pb & 0xFF)
 }
 
 // GetMSB returns the most-significant byte of the pitch bend value.
 func (pb PitchBend) GetMSB() byte {
-	// 0x1F00 is the sum of all powers of 2 from 2^8 to 2^12 (right before 8192, which is 2^13)
-	// to denote the relative range of bits within the first byte of the 16-bit sequence
-	return byte(pb & 0x1F00 >> 8)
+	// https://stackoverflow.com/a/17260211
+	return byte(pb >> 8)
 }

--- a/midiv1/pitch.go
+++ b/midiv1/pitch.go
@@ -1,10 +1,5 @@
 package midiv1
 
-import (
-	"errors"
-	"fmt"
-)
-
 const (
 	// MinPitchBend represents the value of the lowest pitch bend.
 	MinPitchBend PitchBend = -8192
@@ -22,17 +17,20 @@ const (
 // PitchBend is only used in conjunction with Pitch Bend Channel Voice messages.
 type PitchBend int16
 
-var (
-	// ErrInvalidPitchBend represents an invalid MIDI pitch bend value.
-	ErrInvalidPitchBend error = errors.New("invalid MIDI pitch bend")
-)
-
 // NewPitchBend returns a PitchBend instance from an integer value.
-func NewPitchBend(pitchBend int) (PitchBend, error) {
-	if pitchBend < int(MinPitchBend) || pitchBend > int(MaxPitchBend) {
-		return ZeroPitchBend, fmt.Errorf("valid pitch bend is between %d and %d, inclusive: %w", MinPitchBend, MaxPitchBend, ErrInvalidChannel)
+func NewPitchBend(pitchBend int) PitchBend {
+	if pitchBend < int(MinPitchBend) {
+		return MinPitchBend
 	}
-	return PitchBend(pitchBend), nil
+	if pitchBend > int(MaxPitchBend) {
+		return MaxPitchBend
+	}
+	return PitchBend(pitchBend)
+}
+
+// NewPitchBendFromBytes returns a PitchBend instance from a most-significant byte and a least-significant byte.
+func NewPitchBendFromBytes(msb byte, lsb byte) PitchBend {
+	return NewPitchBend(int((int16(msb) << 8) | int16(lsb)))
 }
 
 // GetLSB returns the least-significant byte of the pitch bend value.

--- a/midiv1/pitch.go
+++ b/midiv1/pitch.go
@@ -1,0 +1,48 @@
+package midiv1
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	// MinPitchBend represents the value of the lowest pitch bend.
+	MinPitchBend PitchBend = -8192
+
+	// MaxPitchBend represents the value of the highest pitch bend.
+	MaxPitchBend PitchBend = 8192
+
+	// ZeroPitchBend represents the value for no pitch bend.
+	ZeroPitchBend PitchBend = 0
+)
+
+// PitchBend represents the pitch bend value of an individual MIDI note. Valid values are between -8192 and 8192 inclusive
+// when converted to an integer.
+//
+// PitchBend is only used in conjunction with Pitch Bend Channel Voice messages.
+type PitchBend int16
+
+var (
+	// ErrInvalidPitchBend represents an invalid MIDI pitch bend value.
+	ErrInvalidPitchBend error = errors.New("invalid MIDI pitch bend")
+)
+
+// NewPitchBend returns a PitchBend instance from an integer value.
+func NewPitchBend(pitchBend int) (PitchBend, error) {
+	if pitchBend < int(MinPitchBend) || pitchBend > int(MaxPitchBend) {
+		return ZeroPitchBend, fmt.Errorf("valid pitch bend is between %d and %d, inclusive: %w", MinPitchBend, MaxPitchBend, ErrInvalidChannel)
+	}
+	return PitchBend(pitchBend), nil
+}
+
+// GetLSB returns the least-significant byte of the pitch bend value.
+func (pb PitchBend) GetLSB() byte {
+	return byte(pb & 0x00FF)
+}
+
+// GetMSB returns the most-significant byte of the pitch bend value.
+func (pb PitchBend) GetMSB() byte {
+	// 0x1F00 is the sum of all powers of 2 from 2^8 to 2^12 (right before 8192, which is 2^13)
+	// to denote the relative range of bits within the first byte of the 16-bit sequence
+	return byte(pb & 0x1F00 >> 8)
+}

--- a/midiv1/pitch_bend_message.go
+++ b/midiv1/pitch_bend_message.go
@@ -1,0 +1,94 @@
+package midiv1
+
+import "fmt"
+
+const (
+	// PitchBendMessageStatusCode represents the message code within the status nibble
+	PitchBendMessageCode Nibble = 0b01110000
+
+	// PitchBendMessageLength represents the number of bytes in a full Pitch Bend message.
+	PitchBendMessageLength int = 3
+
+	// PitchBendMessageStatusNibble represents the status nibble within the status byte
+	PitchBendMessageStatusNibble Status = Status(StatusMessageMSB) | Status(PitchBendMessageCode)
+)
+
+// PitchBendMessage represents a Pitch Bend Channel Voice message.
+type PitchBendMessage struct {
+	// Channel represents the channel number where this message will be sent.
+	Channel Channel
+
+	// PitchBend represents the pitch bend change for this message.
+	PitchBend PitchBend
+}
+
+// MarshalMIDI marshalls a PitchBendMessage MIDI message into its raw bytes
+func (pbm PitchBendMessage) MarshalMIDI() ([]byte, error) {
+	return []byte{
+		MakeStatusByte(PitchBendMessageStatusNibble, pbm.Channel),
+		pbm.PitchBend.GetLSB(),
+		pbm.PitchBend.GetMSB(),
+	}, nil
+}
+
+// MarshalRunningStatusMIDI marshalls a running status MIDI message into its raw bytes.
+func (pbm PitchBendMessage) MarshalRunningStatusMIDI() ([]byte, error) {
+	return []byte{
+		pbm.PitchBend.GetLSB(),
+		pbm.PitchBend.GetMSB(),
+	}, nil
+}
+
+// UnmarshalMIDI unmarshalls raw bytes into a PitchBendMessage struct pointer. Pitch Bend messages are
+// represented by three bytes (left to right): status/channel, pitch bend LSB, pitch bend MSB.
+//
+// Example: []byte{0b11110001, 0b11100010, 0b00011101}
+//
+// The example forms a Pitch Bend message for channel 2 (index 1), pitch bend value 7650 (LSB: E2, MSB: 1D).
+func (pbm *PitchBendMessage) UnmarshalMIDI(b []byte) error {
+	// check the number of bytes in the message
+	if len(b) != PitchBendMessageLength {
+		return fmt.Errorf("pitch bend messages are made up of %d bytes, received %d byte(s): %w", PitchBendMessageLength, len(b), ErrUnmarshallingMessage)
+	}
+
+	// make sure this is a status byte with the proper MSB
+	if !ByteHasStatusMSB(b[0]) {
+		return fmt.Errorf("pitch bend messages must have a status MSB: %w", ErrUnmarshallingMessage)
+	}
+
+	// retrieve the channel nibble of the status byte to form the Channel value
+	channel, err := ParseChannelFromStatusByte(b[0])
+	if err != nil {
+		return err
+	}
+
+	// form the pitch bend
+	pitchBend := NewPitchBendFromBytes(b[2], b[1])
+
+	*pbm = PitchBendMessage{
+		Channel:   channel,
+		PitchBend: pitchBend,
+	}
+	return nil
+}
+
+// UnmarshalRunningStatusMIDI unmarshalls raw bytes into a PitchBendMessage struct pointer. Pitch Bend running status messages are
+// represented by two bytes (left to right): pitch bend LSB, pitch bend MSB.
+//
+// Example: []byte{0b11100010, 0b00011101}
+//
+// The example forms a Pitch Bend running status message for pitch bend value 7650 (LSB: E2, MSB: 1D).
+func (pbm *PitchBendMessage) UnmarshalRunningStatusMIDI(b []byte) error {
+	// check the number of bytes in the running status message
+	if len(b) != PitchBendMessageLength-1 {
+		return fmt.Errorf("pitch bend running status messages are made up of %d bytes, received %d byte(s): %w", PitchBendMessageLength-1, len(b), ErrUnmarshallingMessage)
+	}
+
+	// form the pitch bend
+	pitchBend := NewPitchBendFromBytes(b[1], b[0])
+
+	*pbm = PitchBendMessage{
+		PitchBend: pitchBend,
+	}
+	return nil
+}

--- a/midiv1/pitch_bend_message_test.go
+++ b/midiv1/pitch_bend_message_test.go
@@ -1,0 +1,150 @@
+package midiv1
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func Test_PitchBendMessage_MarshalMIDI(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		message  PitchBendMessage
+		expected []byte
+	}{
+		"message marshalls into expected bytes": {
+			message: PitchBendMessage{
+				Channel:   1,
+				PitchBend: 7650,
+			},
+			expected: []byte{0b11110001, 0b11100010, 0b00011101},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := test.message.MarshalMIDI()
+			if err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+			if !bytes.Equal(test.expected, got) {
+				t.Fatalf("expected %#v, got %#v", test.expected, got)
+			}
+		})
+	}
+}
+
+func Test_PitchBendMessage_MarshalRunningStatusMIDI(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		message  PitchBendMessage
+		expected []byte
+	}{
+		"running status message marshalls into expected bytes": {
+			message: PitchBendMessage{
+				PitchBend: 7650,
+			},
+			expected: []byte{0b11100010, 0b00011101},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := test.message.MarshalRunningStatusMIDI()
+			if err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+			if !bytes.Equal(test.expected, got) {
+				t.Fatalf("expected %#v, got %#v", test.expected, got)
+			}
+		})
+	}
+}
+
+func Test_PitchBendMessage_UnmarshalMIDI(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		b               []byte
+		expectedMessage PitchBendMessage
+		err             error
+	}{
+		"byte slice is not proper length": {
+			b:   []byte{0b11110001, 0b01000000},
+			err: ErrUnmarshallingMessage,
+		},
+		"first byte does not have a status MSB": {
+			b:   []byte{0b01110001, 0b01000000, 0b00100000},
+			err: ErrUnmarshallingMessage,
+		},
+		"bytes unmarshal into expected message": {
+			b: []byte{0b11010001, 0b11100010, 0b00011101},
+			expectedMessage: PitchBendMessage{
+				Channel:   1,
+				PitchBend: 7650,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var got PitchBendMessage
+			err := (&got).UnmarshalMIDI(test.b)
+			if test.err == nil && err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+			if test.err != nil {
+				if err == nil {
+					t.Fatalf("expected non-nil %v error, got nil error", test.err)
+				}
+				if !errors.Is(err, test.err) {
+					t.Fatalf("expected %v error, got %v", test.err, err)
+				}
+			}
+			if !reflect.DeepEqual(test.expectedMessage, got) {
+				t.Fatalf("expected %+v, got %+v", test.expectedMessage, got)
+			}
+		})
+	}
+}
+
+func Test_PitchBendMessage_UnmarshalRunningStatusMIDI(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		b               []byte
+		expectedMessage PitchBendMessage
+		err             error
+	}{
+		"byte slice is not proper length": {
+			b:   []byte{0b11110001, 0b11100010, 0b00011101},
+			err: ErrUnmarshallingMessage,
+		},
+		"bytes unmarshal into expected message": {
+			b: []byte{0b11100010, 0b00011101},
+			expectedMessage: PitchBendMessage{
+				PitchBend: 7650,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var got PitchBendMessage
+			err := (&got).UnmarshalRunningStatusMIDI(test.b)
+			if test.err == nil && err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+			if test.err != nil {
+				if err == nil {
+					t.Fatalf("expected non-nil %v error, got nil error", test.err)
+				}
+				if !errors.Is(err, test.err) {
+					t.Fatalf("expected %v error, got %v", test.err, err)
+				}
+			}
+			if !reflect.DeepEqual(test.expectedMessage, got) {
+				t.Fatalf("expected %+v, got %+v", test.expectedMessage, got)
+			}
+		})
+	}
+}

--- a/midiv1/pitch_test.go
+++ b/midiv1/pitch_test.go
@@ -1,0 +1,119 @@
+package midiv1
+
+import "testing"
+
+func Test_NewPitchBend(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		pitchBendInt      int
+		expectedPitchBend PitchBend
+	}{
+		"pitch bend clamps to minimum value": {
+			pitchBendInt:      -8913,
+			expectedPitchBend: MinPitchBend,
+		},
+		"pitch bend clamps to maximum value": {
+			pitchBendInt:      8913,
+			expectedPitchBend: MaxPitchBend,
+		},
+		"pitch bend is intended integer": {
+			pitchBendInt:      53,
+			expectedPitchBend: 53,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := NewPitchBend(test.pitchBendInt)
+			if got != test.expectedPitchBend {
+				t.Fatalf("expected %v, got %v", test.expectedPitchBend, got)
+			}
+		})
+	}
+}
+
+func Test_NewPitchBendFromBytes(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		pitchBendBytes    [2]byte
+		expectedPitchBend PitchBend
+	}{
+		"pitch bend MSB and LSB make up -8192": {
+			pitchBendBytes:    [2]byte{0xE0, 0x00},
+			expectedPitchBend: MinPitchBend,
+		},
+		"pitch bend MSB and LSB make up 8192": {
+			pitchBendBytes:    [2]byte{0x20, 0x00},
+			expectedPitchBend: MaxPitchBend,
+		},
+		"pitch bend MSB and LSB make up 53": {
+			pitchBendBytes:    [2]byte{0x00, 0x35},
+			expectedPitchBend: 53,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := NewPitchBendFromBytes(test.pitchBendBytes[0], test.pitchBendBytes[1])
+			if got != test.expectedPitchBend {
+				t.Fatalf("expected %v, got %v", test.expectedPitchBend, got)
+			}
+		})
+	}
+}
+
+func Test_PitchBend_GetLSB(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		pitchBend   PitchBend
+		expectedLSB byte
+	}{
+		"pitch bend LSB is 0x00": {
+			pitchBend:   MinPitchBend,
+			expectedLSB: 0x00,
+		},
+		"pitch bend LSB is 0x35": {
+			pitchBend:   53,
+			expectedLSB: 0x35,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := test.pitchBend.GetLSB()
+			if got != test.expectedLSB {
+				t.Fatalf("expected %v, got %v", test.expectedLSB, got)
+			}
+		})
+	}
+}
+
+func Test_PitchBend_GetMSB(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		pitchBend   PitchBend
+		expectedMSB byte
+	}{
+		"pitch bend MSB is 0xE0": {
+			pitchBend:   MinPitchBend,
+			expectedMSB: 0xE0,
+		},
+		"pitch bend MSB is 0x20": {
+			pitchBend:   MaxPitchBend,
+			expectedMSB: 0x20,
+		},
+		"pitch bend MSB is 0x00": {
+			pitchBend:   53,
+			expectedMSB: 0x00,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := test.pitchBend.GetMSB()
+			if got != test.expectedMSB {
+				t.Fatalf("expected %v, got %v", test.expectedMSB, got)
+			}
+		})
+	}
+}

--- a/midiv1/polyphonic_key_pressure_message.go
+++ b/midiv1/polyphonic_key_pressure_message.go
@@ -87,7 +87,7 @@ func (pkpm *PolyphonicKeyPressureMessage) UnmarshalMIDI(b []byte) error {
 //
 // Example: []byte{0b01000000, 0b00100000}
 //
-// The example forms a Note-On running status message for note number 64, pressure value 32.
+// The example forms a Polyphonic Key Pressure running status message for note number 64, pressure value 32.
 func (pkpm *PolyphonicKeyPressureMessage) UnmarshalRunningStatusMIDI(b []byte) error {
 	// check the number of bytes in the running status message
 	if len(b) != PolyphonicKeyPressureMessageLength-1 {


### PR DESCRIPTION
Adds Pitch Bend channel voice messages.

This is the first slightly-odd channel voice implementation since the most-significant byte and the least-significant byte of the 16-bit pitch bend value are reversed in the actual message itself.

Closes #8 