### PR TITLE
Adds shared interface across MIDI 1.0 messages

### DIFF
--- a/midiv1/channel_pressure_message.go
+++ b/midiv1/channel_pressure_message.go
@@ -25,6 +25,11 @@ type ChannelPressureMessage struct {
 	Pressure Pressure
 }
 
+// GetMessageName returns the name of this Channel Pressure message.
+func (cpm *ChannelPressureMessage) GetMessageName() string {
+	return "Channel Pressure"
+}
+
 // MarshalMIDI marshalls a ChannelPressureMessage MIDI message into its raw bytes
 func (cpm ChannelPressureMessage) MarshalMIDI() ([]byte, error) {
 	return []byte{

--- a/midiv1/channel_pressure_message.go
+++ b/midiv1/channel_pressure_message.go
@@ -47,6 +47,11 @@ func (cpm ChannelPressureMessage) MarshalRunningStatusMIDI() ([]byte, error) {
 	}, nil
 }
 
+// String returns the human-readable representation of the MIDI message.
+func (cpm *ChannelPressureMessage) String() string {
+	return fmt.Sprintf(MessageStringFormat, MessageVersion, cpm.GetMessageName(), cpm.Channel, cpm.Note, cpm.Pressure)
+}
+
 // UnmarshalMIDI unmarshalls raw bytes into a ChannelPressureMessage struct pointer. Channel Pressure messages are
 // represented by three bytes (left to right): status/channel, note number, note pressure.
 //

--- a/midiv1/channel_pressure_message_test.go
+++ b/midiv1/channel_pressure_message_test.go
@@ -7,6 +7,14 @@ import (
 	"testing"
 )
 
+func Test_ChannelPressureMessage_GetMessageName(t *testing.T) {
+	message := ChannelPressureMessage{}
+	expected := "Channel Pressure"
+	if message.GetMessageName() != expected {
+		t.Fatalf("expected %s, got %s", expected, message.GetMessageName())
+	}
+}
+
 func Test_ChannelPressureMessage_MarshalMIDI(t *testing.T) {
 	t.Parallel()
 	tests := map[string]struct {

--- a/midiv1/channel_pressure_message_test.go
+++ b/midiv1/channel_pressure_message_test.go
@@ -3,11 +3,13 @@ package midiv1
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 )
 
 func Test_ChannelPressureMessage_GetMessageName(t *testing.T) {
+	t.Parallel()
 	message := ChannelPressureMessage{}
 	expected := "Channel Pressure"
 	if message.GetMessageName() != expected {
@@ -69,6 +71,19 @@ func Test_ChannelPressureMessage_MarshalRunningStatusMIDI(t *testing.T) {
 				t.Fatalf("expected %#v, got %#v", test.expected, got)
 			}
 		})
+	}
+}
+
+func Test_ChannelPressureMessage_String(t *testing.T) {
+	t.Parallel()
+	message := ChannelPressureMessage{
+		Channel:  1,
+		Note:     64,
+		Pressure: 32,
+	}
+	expected := fmt.Sprintf("%s:%s:%d:%d:%d", MessageVersion, "Channel Pressure", 1, 64, 32)
+	if message.String() != expected {
+		t.Fatalf("expected %s, got %s", expected, message.String())
 	}
 }
 

--- a/midiv1/message.go
+++ b/midiv1/message.go
@@ -11,6 +11,14 @@ type Message interface {
 	GetMessageName() string
 }
 
+const (
+	// MessageStringFormat is the printf-compatible format for the string representation of a message.
+	MessageStringFormat string = "%s:%s:%d:%d:%d"
+
+	// MessageVersion represents the MIDI version string for messages.
+	MessageVersion string = "MIDI 1.0"
+)
+
 // Nibble represents a set of four bits within a byte.
 type Nibble byte
 

--- a/midiv1/message.go
+++ b/midiv1/message.go
@@ -5,6 +5,12 @@ import (
 	"fmt"
 )
 
+// Message represents a MIDI 1.0 message.
+type Message interface {
+	// GetMessageName returns the human-readable name of the MIDI 1.0 message.
+	GetMessageName() string
+}
+
 // Nibble represents a set of four bits within a byte.
 type Nibble byte
 

--- a/midiv1/note_off_message.go
+++ b/midiv1/note_off_message.go
@@ -28,6 +28,11 @@ type NoteOffMessage struct {
 	Velocity Velocity
 }
 
+// GetMessageName returns the name of this Note-Off message.
+func (nom *NoteOffMessage) GetMessageName() string {
+	return "Note-Off"
+}
+
 // MarshalMIDI marshalls a NoteOffMessage MIDI message into its raw bytes
 func (nom NoteOffMessage) MarshalMIDI() ([]byte, error) {
 	return []byte{
@@ -43,6 +48,11 @@ func (nom NoteOffMessage) MarshalRunningStatusMIDI() ([]byte, error) {
 		byte(nom.Note),
 		byte(nom.Velocity),
 	}, nil
+}
+
+// String returns the human-readable representation of the MIDI message.
+func (nom *NoteOffMessage) String() string {
+	return fmt.Sprintf(MessageStringFormat, MessageVersion, nom.GetMessageName(), nom.Channel, nom.Note, nom.Velocity)
 }
 
 // UnmarshalMIDI unmarshalls raw bytes into a NoteOffMessage struct pointer. Note-Off messages are
@@ -83,11 +93,6 @@ func (nom *NoteOffMessage) UnmarshalMIDI(b []byte) error {
 		Velocity: vel,
 	}
 	return nil
-}
-
-// GetMessageName returns the name of this Note-Off message.
-func (nom *NoteOffMessage) GetMessageName() string {
-	return "Note-Off"
 }
 
 // UnmarshalRunningStatusMIDI unmarshalls raw bytes into a NoteOffMessage struct pointer. Note-Off running status messages are

--- a/midiv1/note_off_message.go
+++ b/midiv1/note_off_message.go
@@ -85,6 +85,11 @@ func (nom *NoteOffMessage) UnmarshalMIDI(b []byte) error {
 	return nil
 }
 
+// GetMessageName returns the name of this Note-Off message.
+func (nom *NoteOffMessage) GetMessageName() string {
+	return "Note-Off"
+}
+
 // UnmarshalRunningStatusMIDI unmarshalls raw bytes into a NoteOffMessage struct pointer. Note-Off running status messages are
 // represented by two bytes (left to right): note number, note velocity.
 //

--- a/midiv1/note_off_message_test.go
+++ b/midiv1/note_off_message_test.go
@@ -7,6 +7,14 @@ import (
 	"testing"
 )
 
+func Test_NotOffMessage_GetMessageName(t *testing.T) {
+	message := NoteOffMessage{}
+	expected := "Note-Off"
+	if message.GetMessageName() != expected {
+		t.Fatalf("expected %s, got %s", expected, message.GetMessageName())
+	}
+}
+
 func Test_NoteOffMessage_MarshalMIDI(t *testing.T) {
 	t.Parallel()
 	tests := map[string]struct {

--- a/midiv1/note_off_message_test.go
+++ b/midiv1/note_off_message_test.go
@@ -3,11 +3,13 @@ package midiv1
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 )
 
 func Test_NotOffMessage_GetMessageName(t *testing.T) {
+	t.Parallel()
 	message := NoteOffMessage{}
 	expected := "Note-Off"
 	if message.GetMessageName() != expected {
@@ -69,6 +71,19 @@ func Test_NoteOffMessage_MarshalRunningStatusMIDI(t *testing.T) {
 				t.Fatalf("expected %#v, got %#v", test.expected, got)
 			}
 		})
+	}
+}
+
+func Test_NoteOffMessage_String(t *testing.T) {
+	t.Parallel()
+	message := NoteOffMessage{
+		Channel:  1,
+		Note:     64,
+		Velocity: 32,
+	}
+	expected := fmt.Sprintf("%s:%s:%d:%d:%d", MessageVersion, "Note-Off", 1, 64, 32)
+	if message.String() != expected {
+		t.Fatalf("expected %s, got %s", expected, message.String())
 	}
 }
 

--- a/midiv1/note_on_message.go
+++ b/midiv1/note_on_message.go
@@ -25,6 +25,11 @@ type NoteOnMessage struct {
 	Velocity Velocity
 }
 
+// GetMessageName returns the name of this Note-On message.
+func (nom *NoteOnMessage) GetMessageName() string {
+	return "Note-On"
+}
+
 // MarshalMIDI marshalls a NoteOnMessage MIDI message into its raw bytes
 func (nom NoteOnMessage) MarshalMIDI() ([]byte, error) {
 	return []byte{

--- a/midiv1/note_on_message.go
+++ b/midiv1/note_on_message.go
@@ -47,6 +47,11 @@ func (nom NoteOnMessage) MarshalRunningStatusMIDI() ([]byte, error) {
 	}, nil
 }
 
+// String returns the human-readable representation of the MIDI message.
+func (nom *NoteOnMessage) String() string {
+	return fmt.Sprintf(MessageStringFormat, MessageVersion, nom.GetMessageName(), nom.Channel, nom.Note, nom.Velocity)
+}
+
 // UnmarshalMIDI unmarshalls raw bytes into a NoteOnMessage struct pointer. Note-On messages are
 // represented by three bytes (left to right): status/channel, note number, note velocity.
 //

--- a/midiv1/note_on_message_test.go
+++ b/midiv1/note_on_message_test.go
@@ -7,6 +7,14 @@ import (
 	"testing"
 )
 
+func Test_NoteOnMessage_GetMessageName(t *testing.T) {
+	message := NoteOnMessage{}
+	expected := "Note-On"
+	if message.GetMessageName() != expected {
+		t.Fatalf("expected %s, got %s", expected, message.GetMessageName())
+	}
+}
+
 func Test_NoteOnMessage_MarshalMIDI(t *testing.T) {
 	t.Parallel()
 	tests := map[string]struct {

--- a/midiv1/note_on_message_test.go
+++ b/midiv1/note_on_message_test.go
@@ -3,11 +3,13 @@ package midiv1
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 )
 
 func Test_NoteOnMessage_GetMessageName(t *testing.T) {
+	t.Parallel()
 	message := NoteOnMessage{}
 	expected := "Note-On"
 	if message.GetMessageName() != expected {
@@ -69,6 +71,19 @@ func Test_NoteOnMessage_MarshalRunningStatusMIDI(t *testing.T) {
 				t.Fatalf("expected %#v, got %#v", test.expected, got)
 			}
 		})
+	}
+}
+
+func Test_NoteOnMessage_String(t *testing.T) {
+	t.Parallel()
+	message := NoteOnMessage{
+		Channel:  1,
+		Note:     64,
+		Velocity: 32,
+	}
+	expected := fmt.Sprintf("%s:%s:%d:%d:%d", MessageVersion, "Note-On", 1, 64, 32)
+	if message.String() != expected {
+		t.Fatalf("expected %s, got %s", expected, message.String())
 	}
 }
 

--- a/midiv1/pitch_bend_message.go
+++ b/midiv1/pitch_bend_message.go
@@ -22,6 +22,11 @@ type PitchBendMessage struct {
 	PitchBend PitchBend
 }
 
+// GetMessageName returns the name of this Pitch Bend message.
+func (pbm *PitchBendMessage) GetMessageName() string {
+	return "Pitch Bend"
+}
+
 // MarshalMIDI marshalls a PitchBendMessage MIDI message into its raw bytes
 func (pbm PitchBendMessage) MarshalMIDI() ([]byte, error) {
 	return []byte{

--- a/midiv1/pitch_bend_message.go
+++ b/midiv1/pitch_bend_message.go
@@ -11,6 +11,9 @@ const (
 
 	// PitchBendMessageStatusNibble represents the status nibble within the status byte
 	PitchBendMessageStatusNibble Status = Status(StatusMessageMSB) | Status(PitchBendMessageCode)
+
+	// PitchBendMessageStringFormat represents the printf-compatible format specifically for a Pitch Bend message string.
+	PitchBendMessageStringFormat string = "%s:%s:%d:%d"
 )
 
 // PitchBendMessage represents a Pitch Bend Channel Voice message.
@@ -42,6 +45,11 @@ func (pbm PitchBendMessage) MarshalRunningStatusMIDI() ([]byte, error) {
 		pbm.PitchBend.GetLSB(),
 		pbm.PitchBend.GetMSB(),
 	}, nil
+}
+
+// String returns the human-readable representation of the MIDI message.
+func (pbm *PitchBendMessage) String() string {
+	return fmt.Sprintf(PitchBendMessageStringFormat, MessageVersion, pbm.GetMessageName(), pbm.Channel, pbm.PitchBend)
 }
 
 // UnmarshalMIDI unmarshalls raw bytes into a PitchBendMessage struct pointer. Pitch Bend messages are

--- a/midiv1/pitch_bend_message_test.go
+++ b/midiv1/pitch_bend_message_test.go
@@ -7,6 +7,14 @@ import (
 	"testing"
 )
 
+func Test_PitchBendMessage_GetMessageName(t *testing.T) {
+	message := PitchBendMessage{}
+	expected := "Pitch Bend"
+	if message.GetMessageName() != expected {
+		t.Fatalf("expected %s, got %s", expected, message.GetMessageName())
+	}
+}
+
 func Test_PitchBendMessage_MarshalMIDI(t *testing.T) {
 	t.Parallel()
 	tests := map[string]struct {

--- a/midiv1/pitch_bend_message_test.go
+++ b/midiv1/pitch_bend_message_test.go
@@ -3,11 +3,13 @@ package midiv1
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 )
 
 func Test_PitchBendMessage_GetMessageName(t *testing.T) {
+	t.Parallel()
 	message := PitchBendMessage{}
 	expected := "Pitch Bend"
 	if message.GetMessageName() != expected {
@@ -67,6 +69,18 @@ func Test_PitchBendMessage_MarshalRunningStatusMIDI(t *testing.T) {
 				t.Fatalf("expected %#v, got %#v", test.expected, got)
 			}
 		})
+	}
+}
+
+func Test_PitchBendMessage_String(t *testing.T) {
+	t.Parallel()
+	message := PitchBendMessage{
+		Channel:   1,
+		PitchBend: 7650,
+	}
+	expected := fmt.Sprintf("%s:%s:%d:%d", MessageVersion, "Pitch Bend", 1, 7650)
+	if message.String() != expected {
+		t.Fatalf("expected %s, got %s", expected, message.String())
 	}
 }
 

--- a/midiv1/polyphonic_key_pressure_message.go
+++ b/midiv1/polyphonic_key_pressure_message.go
@@ -47,6 +47,11 @@ func (pkpm PolyphonicKeyPressureMessage) MarshalRunningStatusMIDI() ([]byte, err
 	}, nil
 }
 
+// String returns the human-readable representation of the MIDI message.
+func (pkpm *PolyphonicKeyPressureMessage) String() string {
+	return fmt.Sprintf(MessageStringFormat, MessageVersion, pkpm.GetMessageName(), pkpm.Channel, pkpm.Note, pkpm.Pressure)
+}
+
 // UnmarshalMIDI unmarshalls raw bytes into a PolyphonicKeyPressureMessage struct pointer. Polyphonic Key Pressure messages are
 // represented by three bytes (left to right): status/channel, note number, note pressure.
 //

--- a/midiv1/polyphonic_key_pressure_message.go
+++ b/midiv1/polyphonic_key_pressure_message.go
@@ -25,6 +25,11 @@ type PolyphonicKeyPressureMessage struct {
 	Pressure Pressure
 }
 
+// GetMessageName returns the name of this Polyphonic Key Pressure message.
+func (pkpm *PolyphonicKeyPressureMessage) GetMessageName() string {
+	return "Polyphonic Key Pressure"
+}
+
 // MarshalMIDI marshalls a PolyphonicKeyPressureMessage MIDI message into its raw bytes
 func (pkpm PolyphonicKeyPressureMessage) MarshalMIDI() ([]byte, error) {
 	return []byte{

--- a/midiv1/polyphonic_key_pressure_message_test.go
+++ b/midiv1/polyphonic_key_pressure_message_test.go
@@ -3,11 +3,13 @@ package midiv1
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 )
 
 func Test_PolyphonicKeyPressureMessage_GetMessageName(t *testing.T) {
+	t.Parallel()
 	message := PolyphonicKeyPressureMessage{}
 	expected := "Polyphonic Key Pressure"
 	if message.GetMessageName() != expected {
@@ -69,6 +71,19 @@ func Test_PolyphonicKeyPressureMessage_MarshalRunningStatusMIDI(t *testing.T) {
 				t.Fatalf("expected %#v, got %#v", test.expected, got)
 			}
 		})
+	}
+}
+
+func Test_PolyphonicKeyPressureMessage_String(t *testing.T) {
+	t.Parallel()
+	message := PolyphonicKeyPressureMessage{
+		Channel:  1,
+		Note:     64,
+		Pressure: 32,
+	}
+	expected := fmt.Sprintf("%s:%s:%d:%d:%d", MessageVersion, "Polyphonic Key Pressure", 1, 64, 32)
+	if message.String() != expected {
+		t.Fatalf("expected %s, got %s", expected, message.String())
 	}
 }
 

--- a/midiv1/polyphonic_key_pressure_message_test.go
+++ b/midiv1/polyphonic_key_pressure_message_test.go
@@ -7,6 +7,14 @@ import (
 	"testing"
 )
 
+func Test_PolyphonicKeyPressureMessage_GetMessageName(t *testing.T) {
+	message := PolyphonicKeyPressureMessage{}
+	expected := "Polyphonic Key Pressure"
+	if message.GetMessageName() != expected {
+		t.Fatalf("expected %s, got %s", expected, message.GetMessageName())
+	}
+}
+
 func Test_PolyphonicKeyPressureMessage_MarshalMIDI(t *testing.T) {
 	t.Parallel()
 	tests := map[string]struct {


### PR DESCRIPTION
Adds a shared interface across MIDI 1.0 messages.

This also adds the `String()` pointer receiver method to allow for human-readable output and logging when necessary.

Closes #27 